### PR TITLE
Migrate Azure AI SDKs to v2: use standalone AgentsClient

### DIFF
--- a/libs/azure-ai/langchain_azure_ai/agents/agent_service.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/agent_service.py
@@ -13,7 +13,7 @@ from typing import (
     Union,
 )
 
-from azure.ai.projects import AIProjectClient
+from azure.ai.agents import AgentsClient
 from azure.core.credentials import TokenCredential
 from azure.identity import DefaultAzureCredential
 from langchain.agents import AgentState
@@ -157,8 +157,8 @@ class AgentServiceFactory(BaseModel):
 
         return values
 
-    def _initialize_client(self) -> AIProjectClient:
-        """Initialize the AIProjectClient."""
+    def _initialize_client(self) -> AgentsClient:
+        """Initialize the AgentsClient."""
         credential: TokenCredential
         if self.credential is None:
             credential = DefaultAzureCredential()
@@ -168,10 +168,10 @@ class AgentServiceFactory(BaseModel):
         if self.project_endpoint is None:
             raise ValueError(
                 "The `project_endpoint` parameter must be specified to create the "
-                "AIProjectClient."
+                "AgentsClient."
             )
 
-        return AIProjectClient(
+        return AgentsClient(
             endpoint=self.project_endpoint,
             credential=credential,
             **self.client_kwargs,
@@ -205,7 +205,7 @@ class AgentServiceFactory(BaseModel):
                 logger.warning("[WARNING] No agent ID found in the graph metadata.")
             else:
                 for agent_id in agent_ids:
-                    client.agents.delete_agent(agent_id)
+                    client.delete_agent(agent_id)
                     logger.info("Deleted agent with ID: %s", agent_id)
 
     def get_agents_id_from_graph(self, graph: CompiledStateGraph) -> Set[str]:
@@ -254,7 +254,7 @@ class AgentServiceFactory(BaseModel):
         if not isinstance(instructions, str):
             raise ValueError("Only string instructions are supported momentarily.")
 
-        logger.info("Initializing AIProjectClient")
+        logger.info("Initializing AgentsClient")
         client = self._initialize_client()
 
         return PromptBasedAgentNode(

--- a/libs/azure-ai/langchain_azure_ai/agents/prebuilt/declarative.py
+++ b/libs/azure-ai/langchain_azure_ai/agents/prebuilt/declarative.py
@@ -28,7 +28,7 @@ from azure.ai.agents.models import (
     ToolResources,
     ToolSet,
 )
-from azure.ai.projects import AIProjectClient
+from azure.ai.agents import AgentsClient
 from azure.core.exceptions import HttpResponseError
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel, ChatResult
@@ -274,8 +274,8 @@ def _content_from_human_message(
 class _PromptBasedAgentModel(BaseChatModel):
     """A LangChain chat model wrapper for Azure AI Foundry prompt-based agents."""
 
-    client: AIProjectClient
-    """The AIProjectClient instance."""
+    client: AgentsClient
+    """The AgentsClient instance."""
 
     agent: Agent
     """The agent instance."""
@@ -324,7 +324,7 @@ class _PromptBasedAgentModel(BaseChatModel):
                 file_name = file_paths.get(file_id, f"{file_id}.png")
                 with tempfile.TemporaryDirectory() as target_dir:
                     logger.info("Downloading image file %s as %s", file_id, file_name)
-                    self.client.agents.files.save(
+                    self.client.files.save(
                         file_id=file_id,
                         file_name=file_name,
                         target_dir=target_dir,
@@ -375,7 +375,7 @@ class _PromptBasedAgentModel(BaseChatModel):
                 f"Run {self.run.id} failed with error: {self.run.last_error}"
             )
         elif self.run.status == "completed":
-            response = self.client.agents.messages.list(
+            response = self.client.messages.list(
                 thread_id=self.run.thread_id,
                 run_id=self.run.id,
                 order=ListSortOrder.ASCENDING,
@@ -433,8 +433,8 @@ class PromptBasedAgentNode(RunnableCallable):
 
     name: str = "PromptAgent"
 
-    _client: AIProjectClient
-    """The AIProjectClient instance to use."""
+    _client: AgentsClient
+    """The AgentsClient instance to use."""
 
     _agent: Optional[Agent] = None
     """The agent instance to use."""
@@ -457,7 +457,7 @@ class PromptBasedAgentNode(RunnableCallable):
 
     def __init__(
         self,
-        client: AIProjectClient,
+        client: AgentsClient,
         model: str,
         instructions: str,
         name: str,
@@ -480,7 +480,7 @@ class PromptBasedAgentNode(RunnableCallable):
         """Initialize the DeclarativeChatAgentNode.
 
         Args:
-            client: The AIProjectClient instance to use.
+            client: The AgentsClient instance to use.
             model: The model to use for the agent.
             instructions: The prompt instructions to use for the agent.
             name: The name of the agent.
@@ -505,7 +505,7 @@ class PromptBasedAgentNode(RunnableCallable):
 
         if agent_id is not None:
             try:
-                self._agent = self._client.agents.get_agent(agent_id=agent_id)
+                self._agent = self._client.get_agent(agent_id=agent_id)
                 self._agent_id = self._agent.id
                 self._agent_name = self._agent.name
             except HttpResponseError as e:
@@ -541,7 +541,7 @@ class PromptBasedAgentNode(RunnableCallable):
             if tool_resources is not None:
                 agent_params["tool_resources"] = tool_resources
 
-        self._agent = client.agents.create_agent(**agent_params)
+        self._agent = client.create_agent(**agent_params)
         self._agent_id = self._agent.id
         self._agent_name = name
         logger.info(
@@ -551,7 +551,7 @@ class PromptBasedAgentNode(RunnableCallable):
     def delete_agent_from_node(self) -> None:
         """Delete an agent associated with a DeclarativeChatAgentNode node."""
         if self._agent_id is not None:
-            self._client.agents.delete_agent(self._agent_id)
+            self._client.delete_agent(self._agent_id)
             logger.info("Deleted agent with ID: %s", self._agent_id)
 
             self._agent_id = None
@@ -576,7 +576,7 @@ class PromptBasedAgentNode(RunnableCallable):
             )
 
         if self._thread_id is None:
-            thread = self._client.agents.threads.create()
+            thread = self._client.threads.create()
             self._thread_id = thread.id
             logger.info("Created new thread with ID: %s", self._thread_id)
 
@@ -587,14 +587,14 @@ class PromptBasedAgentNode(RunnableCallable):
         if isinstance(message, ToolMessage):
             logger.info("Submitting tool message with ID %s", message.id)
             if self._pending_run_id:
-                run = self._client.agents.runs.get(
+                run = self._client.runs.get(
                     thread_id=self._thread_id, run_id=self._pending_run_id
                 )
                 if run.status == "requires_action" and isinstance(
                     run.required_action, SubmitToolOutputsAction
                 ):
                     tool_outputs = [_tool_message_to_output(message)]
-                    self._client.agents.runs.submit_tool_outputs(
+                    self._client.runs.submit_tool_outputs(
                         thread_id=self._thread_id,
                         run_id=self._pending_run_id,
                         tool_outputs=tool_outputs,
@@ -611,7 +611,7 @@ class PromptBasedAgentNode(RunnableCallable):
                 )
         elif isinstance(message, HumanMessage):
             logger.info("Submitting human message %s", message.content)
-            self._client.agents.messages.create(
+            self._client.messages.create(
                 thread_id=self._thread_id,
                 role="user",
                 content=_content_from_human_message(message),  # type: ignore[arg-type]
@@ -621,19 +621,19 @@ class PromptBasedAgentNode(RunnableCallable):
 
         if self._pending_run_id is None:
             logger.info("Creating and processing new run...")
-            run = self._client.agents.runs.create(
+            run = self._client.runs.create(
                 thread_id=self._thread_id,
                 agent_id=self._agent_id,
             )
         else:
             logger.info("Getting existing run %s...", self._pending_run_id)
-            run = self._client.agents.runs.get(
+            run = self._client.runs.get(
                 thread_id=self._thread_id, run_id=self._pending_run_id
             )
 
         while run.status in ["queued", "in_progress"]:
             time.sleep(self._polling_interval)
-            run = self._client.agents.runs.get(thread_id=self._thread_id, run_id=run.id)
+            run = self._client.runs.get(thread_id=self._thread_id, run_id=run.id)
 
         agent_chat_model = _PromptBasedAgentModel(
             client=self._client,

--- a/libs/azure-ai/pyproject.toml
+++ b/libs/azure-ai/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10.0,<4.0"
 dependencies = [
   "aiohttp~=3.10",
   "azure-ai-inference[opentelemetry]>=1.0.0b9,<2.0",
-  "azure-ai-projects~=1.0",
+  "azure-ai-projects>=2.0.0b3,<3.0",
   "azure-core~=1.32",
   "azure-cosmos>=4.14.0b1,<5.0",
   "azure-identity~=1.15",
@@ -23,7 +23,7 @@ dependencies = [
 
 [project.optional-dependencies]
 agents = [
-  "azure-ai-agents==1.2.0b5",
+  "azure-ai-agents>=1.2.0b5,<2.0",
 ]
 opentelemetry = [
   "azure-monitor-opentelemetry~=1.6",


### PR DESCRIPTION
## Summary

Migrates the Azure AI SDK dependencies from v1 to v2, aligning with the new architecture where agent runtime operations use a standalone `AgentsClient`.

## Changes

### Dependencies (`pyproject.toml`)
- `azure-ai-projects`: `~=1.0` → `>=2.0.0b3,<3.0`
- `azure-ai-agents`: `==1.2.0b5` → `>=1.2.0b5,<2.0`
- `azure-ai-inference`: unchanged

### Code changes
| File | Change |
|------|--------|
| `agents/agent_service.py` | `AIProjectClient` → `AgentsClient` for client init and `delete_agent()` |
| `agents/prebuilt/declarative.py` | Replace all `client.agents.*` calls with direct `AgentsClient` methods (12 call sites) |
| `utils/utils.py` | No changes needed — v2 `AIProjectClient` has compatible `connections`/`telemetry` APIs |
| `agents/prebuilt/tools.py` | No changes needed — already imports from `azure.ai.agents.models` |

### Key v1 → v2 difference
In v1, `AIProjectClient.agents` provided both management AND runtime (thread/run/message) operations. In v2, these are split:
- `AIProjectClient.agents` → **management-only** (CRUD agent definitions, versioning)
- `AgentsClient` from `azure-ai-agents` → **runtime operations** (threads, messages, runs, files)

## Testing
- All 98 unit tests pass (3 skipped)
- v1 and v2 SDK APIs verified via separate venvs
